### PR TITLE
Bump matc version to 0.1.3 in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "matc"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aes",
  "anyhow",


### PR DESCRIPTION
## Summary
- Updates the `matc` package version from `0.1.2` to `0.1.3` in the `Cargo.lock` file

## Changes
- Modified `Cargo.lock` to reflect the new version of the `matc` package

## Test plan
- Ensure the project builds successfully with the updated dependency version
- Run existing tests to verify no regressions due to version bump

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/224960c4-e0c5-40c9-8fc9-eeaff29d2267